### PR TITLE
Added multizone group routes (solves #24)

### DIFF
--- a/assistant.apib
+++ b/assistant.apib
@@ -33,7 +33,7 @@ Any combination of fields can be used.
 Get the currently set alarms and timers.
 
 For alarms: `status`: `1` for set up and `2` for currently ringing.  
-For alarms: `status`: `1` for set up and `3` for currently ringing.
+For timers: `status`: `1` for set up and `3` for currently ringing.
 ### Get alarms and timers [GET]
 
   + Request

--- a/connectivity.apib
+++ b/connectivity.apib
@@ -121,13 +121,6 @@ Temporarily turn on bluetooth discoveribility. Used to connect new devices.
 
   + Response 200
 
-
-<<<<<<< HEAD
-## Connect bluetooth device [/setup/bluetooth/connect]
-Connect a new bluetooth device.
-### Connect bluetooth device [POST]
-Not tested
-=======
 ## Connect / Disconnect bluetooth device [/setup/bluetooth/connect]
 Connect or disconnect an existing bluetooth device. To disconnect, send `false` instead of `true`.
 **Note:** This is not the same as pairing and forgetting a device.
@@ -137,4 +130,4 @@ Connect or disconnect an existing bluetooth device. To disconnect, send `false` 
       { "connect": true }
 
   + Response 200
->>>>>>> rithvikvibhu/master
+

--- a/connectivity.apib
+++ b/connectivity.apib
@@ -59,3 +59,9 @@ Temporarily turn on bluetooth discoveribility. Used to connect new devices.
       { "enable_discovery": true }
 
   + Response 200
+
+
+## Connect bluetooth device [/setup/bluetooth/connect]
+Connect a new bluetooth device.
+### Connect bluetooth device [POST]
+Not tested

--- a/device-settings.apib
+++ b/device-settings.apib
@@ -49,6 +49,35 @@ Since normal volume can be controlled for night mode, if night mode is active th
 
   + Response 200
 
+## Join group [/setup/multizone/leave_group]
+Join a multizone group.
+**Note:**
+uuid can be found at /setup/eureka_info?params=multizone
+### Join group [POST]
+Not tested
+
+## Leave group [/setup/multizone/leave_group]
+Leave a multizone group.
+**Note:**
+uuid can be found at /setup/eureka_info?params=multizone
+### Leave group [POST]
+
+  + Request (application/json)
+      { "uuid": "< MULTIZONE GROUP UUID >" }
+
+  + Response 200
+
+## Disband group [/setup/multizone/leave_group]
+Disband (delete) a multizone group.
+**Note:**
+uuid can be found at /setup/eureka_info?params=multizone
+### Disband group [POST]
+
+  + Request (application/json)
+      { "uuid": "< MULTIZONE GROUP UUID >" }
+
+  + Response 200
+
 
 ## Reboot device [/setup/reboot]
 Reboot the device.


### PR DESCRIPTION
Added routes:
- /setup/multizone/join_group
- /setup/multizone/leave_group
- /setup/multizone/disband_group

join_group is still untested however. I couldn't find good data to pass.

Disband_group is kind of funky. In the app, it appears to only have made the device disbanding the group leave, but if you try to make changes (through the app) it fails. The group still seems to show up in the "linked devices" section.

Solves #24