### PR TITLE
Mention reboot with OTA firmware update argument

### DIFF
--- a/GoogleHome.openapi3.json
+++ b/GoogleHome.openapi3.json
@@ -867,8 +867,8 @@
         "tags": [
           "Device Settings"
         ],
-        "summary": "Reboot and Factory Reset",
-        "description": "This can simply reboot the device (`params: \"now\"`) or factory reset the device (`params: \"fdr\"`).",
+        "summary": "Reboot, Update or Factory Reset",
+        "description": "This can simply reboot the device (`params: \"now\"`), force an update (`params: \"ota foreground\"`) or factory reset the device (`params: \"fdr\"`).",
         "operationId": "RebootandFactoryReset",
         "parameters": [],
         "requestBody": {


### PR DESCRIPTION
TL;DR: This PR adds mention of the third possible param  `ota foreground` for the `/setup/reboot` endpoint.

There are 3 values for the `param` argument of the `/setup/reboot` argument known so far:
- `now` to just reboot
- `fdr` force device reset (factory-reset)
- `ota foreground` request device to update firmware

This firmware update may help people who have factory-reset their device after the March 9 certificate expiry debacle, which has bricked millions of 2nd-gen Chromecast devices worldwide.


**Backstory:** 
 
On March 9th 2025 Google let a certificate expire that bricked all 2nd-generation Chromecast devices. Google said it is working on a solution (likely: disable verification in Google Home app, then push a firmware update), but it warns users not to factory-reset their device, as that will get you stuck in a situation where the device can't be connected to WiFi anymore, and thus won't be able to receive the firmware update.
 
For those who have already performed factory reset in attempt to fix the issue will now have a device that can't be set up (connected to wifi) either. Google said they'll also release instructions to recover bricked devices that have been factory reset after the certificate expired. See [this post on Reddit by the official Google account](https://www.reddit.com/r/Chromecast/comments/1j7lhrs/comment/mgzcw4e/?utm_source=share&utm_medium=web3x&utm_name=web3xcss&utm_term=1)

If you already factory reset your device (like me) and you are impatient (also like me), then you can use the LocalAPI to connect the Chromecast device back to the WiFi (for example: use [this script](https://gist.github.com/interfect/5f68381d55658d334e2bc4619d796476) ), then trigger a forced OTA update via the LocalAPI. 

The OTA update seems to fail for now citing a 'network error' after displaying 'updating 0%' for a while. 
This may be due to the expired certificate, or just because there is no update available yet (the CC probably won't expect a firmware update request from the Home app unless there is one available). 
Hopefully this this firmware update trigger will start working once Google releases a firmware with the update certificates.  If not, we'll have to wait for the official instructions from Google. Nonetheless, for sake of completeness it won't hurt to mention this third option for the `param` value of the `/setup/reboot` endpoint.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Expanded the device operations endpoint to include a software update option in addition to rebooting and factory resetting.
	- Updated the API's descriptive messaging to clearly communicate the new range of available operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->